### PR TITLE
Init context at beginning of the connection.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -5,7 +5,7 @@
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  revision = "05f48f4eaf0e05663b562bab533cdd472238ce29"
+  revision = "93b26e6a70e37abb14f2f88194949312b0592a84"
 
 [[projects]]
   branch = "master"
@@ -13,9 +13,20 @@
   packages = ["."]
   revision = "5ed622c449da6d44c3c8329331ff47a9e5844f71"
 
+[[projects]]
+  branch = "master"
+  name = "github.com/wpajqz/linker"
+  packages = [
+    ".",
+    "codec",
+    "utils/convert",
+    "utils/encrypt"
+  ]
+  revision = "6112fb8aebca49e7e62f0ec21e64bb20c8891736"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "722dc7c98f56ff4ce0cc28f2d34b4ca2216de90390a8df51a3aeb6390631ccce"
+  inputs-digest = "1b662a903809aeee17b2ef8d1b1f893dd5cf094551d987f9a6d3f959ecfef4ba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,8 +72,4 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/spf13/cobra"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/gorilla/websocket"

--- a/context.go
+++ b/context.go
@@ -70,9 +70,9 @@ type (
 	}
 )
 
-func NewContextTcp(conn net.Conn, OperateType uint32, Sequence int64, Header, Body []byte, config Config) *ContextTcp {
+func NewContextTcp(ctx context.Context, conn net.Conn, OperateType uint32, Sequence int64, Header, Body []byte, config Config) *ContextTcp {
 	return &ContextTcp{
-		Context:     context.Background(),
+		Context:     ctx,
 		Conn:        conn,
 		operateType: OperateType,
 		sequence:    Sequence,

--- a/tcp.go
+++ b/tcp.go
@@ -1,6 +1,7 @@
 package linker
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,7 +13,7 @@ import (
 )
 
 func (s *Server) handleTCPConnection(conn *net.TCPConn) error {
-	var ctx Context = &ContextTcp{Conn: conn}
+	var ctx = &ContextTcp{Context: context.Background(), Conn: conn}
 	if s.constructHandler != nil {
 		s.constructHandler.Handle(ctx)
 	}
@@ -90,12 +91,12 @@ func (s *Server) handleTCPConnection(conn *net.TCPConn) error {
 			return err
 		}
 
-		ctx = NewContextTcp(conn, rp.Operator, rp.Sequence, rp.Header, rp.Body, s.config)
-		go s.handleTCPPacket(ctx, conn, rp)
+		ctx = NewContextTcp(ctx.Context, conn, rp.Operator, rp.Sequence, rp.Header, rp.Body, s.config)
+		go s.handleTCPPacket(ctx, rp)
 	}
 }
 
-func (s *Server) handleTCPPacket(ctx Context, conn net.Conn, rp Packet) {
+func (s *Server) handleTCPPacket(ctx Context, rp Packet) {
 	defer func() {
 		if r := recover(); r != nil {
 			if s.errorHandler != nil {
@@ -133,7 +134,7 @@ func (s *Server) handleTCPPacket(ctx Context, conn net.Conn, rp Packet) {
 	ctx.Success(nil) // If it don't call the function of Success or Error, deal it by default
 }
 
-// 开始运行Tcp服务
+// RunTCP 开始运行Tcp服务
 func (s *Server) RunTCP(name, address string) error {
 	tcpAddr, err := net.ResolveTCPAddr(name, address)
 	if err != nil {


### PR DESCRIPTION
在tcp服务端一接收到连接就创建一个context，保证在一个包都没有收发时ctx的方法也都是有效的，不会panic。